### PR TITLE
Modified the ajax_link functions

### DIFF
--- a/ajax_reader/ajax_reader.module
+++ b/ajax_reader/ajax_reader.module
@@ -30,6 +30,9 @@ function ajax_link_response($type = 'ajax', $nid = 0) {
     );
     ajax_deliver($page);
   }
+  elseif ($nid > 0) {
+    drupal_goto('node/' . $nid);
+  }
   else {
     $output = '<div id="content">' . $output . '</div>';
     return $output;


### PR DESCRIPTION
to drupal_goto the node if there is no JS. This should keep the "nojs" version of the path from being registered by search engines (And avoid duplicate content.
